### PR TITLE
Add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,81 @@
+name: Bug report
+description: Report a reproducible bug or platform compatibility problem
+title: "[bug] "
+labels:
+  - bug
+body:
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: Describe the bug and the expected behavior.
+    validations:
+      required: true
+  - type: dropdown
+    id: platform
+    attributes:
+      label: Platform
+      options:
+        - macOS
+        - Linux
+        - Windows native
+        - WSL
+        - Other
+    validations:
+      required: true
+  - type: input
+    id: os_version
+    attributes:
+      label: OS version
+      placeholder: e.g. macOS 15.4, Ubuntu 24.04, Windows 11 24H2
+    validations:
+      required: true
+  - type: input
+    id: shell
+    attributes:
+      label: Shell
+      placeholder: e.g. zsh, bash, PowerShell, cmd
+    validations:
+      required: true
+  - type: input
+    id: node_version
+    attributes:
+      label: Node.js version
+      placeholder: e.g. v22.14.0
+    validations:
+      required: true
+  - type: input
+    id: go_version
+    attributes:
+      label: Go version
+      placeholder: e.g. go1.24.1
+    validations:
+      required: true
+  - type: input
+    id: gopls_version
+    attributes:
+      label: gopls version
+      placeholder: e.g. golang.org/x/tools/gopls v0.21.1
+    validations:
+      required: true
+  - type: dropdown
+    id: gvm
+    attributes:
+      label: Are you using GVM?
+      options:
+        - "yes"
+        - "no"
+        - not sure
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs or output
+      description: Paste the smallest useful output.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Contribution guide
+    url: https://github.com/bchh-s/codex-gopls-mcp/blob/main/CONTRIBUTING.md
+    about: Read the contribution guide before filing platform support or compatibility issues.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,42 @@
+name: Feature request
+description: Propose a new feature, support target, or workflow change
+title: "[feature] "
+labels:
+  - enhancement
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What problem are you trying to solve?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: Describe the change you want.
+    validations:
+      required: true
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      options:
+        - Go support
+        - Windows support
+        - Linux support
+        - macOS support
+        - MCP protocol behavior
+        - Docs
+        - CI
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Validation plan
+      description: How should this be tested?
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/platform_support.yml
+++ b/.github/ISSUE_TEMPLATE/platform_support.yml
@@ -1,0 +1,46 @@
+name: Platform support
+description: Track validation or support work for macOS, Linux, WSL, or native Windows
+title: "[platform] "
+labels:
+  - enhancement
+  - platform
+body:
+  - type: dropdown
+    id: target
+    attributes:
+      label: Target platform
+      options:
+        - macOS
+        - Linux
+        - WSL
+        - Windows native
+    validations:
+      required: true
+  - type: textarea
+    id: motivation
+    attributes:
+      label: Motivation
+      description: Why should this platform be supported or validated?
+    validations:
+      required: true
+  - type: textarea
+    id: gaps
+    attributes:
+      label: Known gaps
+      description: List the shell, path, toolchain, or filesystem assumptions that may block support.
+    validations:
+      required: true
+  - type: textarea
+    id: validation_plan
+    attributes:
+      label: Validation plan
+      description: Describe the real environment or CI runner that should be used. Do not treat Docker on macOS or Linux as native Windows validation.
+    validations:
+      required: true
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Checklist
+      options:
+        - label: I understand that support should not be claimed without real validation
+          required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,28 @@
+## Summary
+
+- 
+
+## Linked Issue
+
+- Closes #
+- If there is no linked issue, explain why this change is still small enough to review safely.
+
+## Validation
+
+- [ ] `node --check server.js`
+- [ ] cross-platform smoke workflow passes
+- [ ] docs updated if setup, support status, or behavior changed
+- [ ] platform-related changes were tested in a real target environment or an equivalent CI runner
+
+## Environment Notes
+
+- OS:
+- Shell:
+- Node.js:
+- Go:
+- `gopls`:
+- Native Windows or WSL:
+
+## Support Claim Check
+
+- [ ] I am not claiming broader platform support than what was actually tested

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,70 @@
+# Contributing
+
+Thanks for contributing.
+
+This repository is small, but it touches local toolchains, shell behavior, and MCP integration. Compatibility claims should be made carefully.
+
+## Ground Rules
+
+- For non-trivial changes, open an issue before opening a PR.
+- For platform support work, always open an issue first.
+- Do not describe a platform as supported unless it has been validated in a real environment or in CI that meaningfully exercises that platform.
+- Keep changes small and scoped. Prefer follow-up issues over broad refactors.
+
+## When To Open An Issue First
+
+Open an issue before coding if the change involves:
+
+- Windows support
+- Linux support differences
+- shell or path behavior
+- toolchain detection changes
+- changes to MCP behavior or exposed tools
+- breaking changes in setup or usage
+
+## Environment Details To Include
+
+For bugs and compatibility reports, include:
+
+- OS and version
+- shell
+- Codex version if relevant
+- Node.js version
+- Go version
+- `gopls` version
+- whether GVM is in use
+- whether the environment is native Windows, WSL, macOS, or Linux
+
+## Pull Requests
+
+PRs should:
+
+- link the issue they address
+- describe the exact environment used for validation
+- update docs if setup, support status, or behavior changed
+- avoid claiming support broader than what was actually tested
+
+## Testing Expectations
+
+At minimum, keep the cross-platform smoke workflow green.
+
+The smoke workflow intentionally tracks:
+
+- the latest stable Go release
+- `gopls@latest`
+
+This repository does not treat older Go versions as a standing compatibility promise unless that is explicitly documented.
+
+For Windows-related work:
+
+- CI on a Windows runner is expected
+- a note about native Windows vs WSL is expected
+- if behavior is only validated in WSL, say that explicitly
+
+## Support Language
+
+Use these labels carefully in docs and PRs:
+
+- "supported" means tested and intentionally maintained
+- "expected to work" means plausible, but not fully validated
+- "experimental" means not yet stable enough for a support claim


### PR DESCRIPTION
## Summary
- add issue templates for bugs, features, and platform support
- add a pull request template
- add CONTRIBUTING.md with review and support-language rules

## Notes
- split out from the Windows and smoke CI work so the PR scope stays aligned with the original tracking issue
- no runtime behavior changes